### PR TITLE
Bugfix[TEO-1014] - Improper label resize causes the filters to miss-align

### DIFF
--- a/frontend/src/components/DataTableFilters.tsx
+++ b/frontend/src/components/DataTableFilters.tsx
@@ -93,7 +93,7 @@ const DataTableFilters = ({
       </CardHeader>
       <div className={classNames(filtersCollapsed ? '' : 'hidden')}>
         <CardBody>
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 2xl:grid-cols-4 gap-4 md:gap-6">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-4 md:gap-6">
             {children}
           </div>
         </CardBody>


### PR DESCRIPTION
[[1014]](https://wearetribus.atlassian.net/browse/TEO-1014)